### PR TITLE
Add GTFS loaders with snapshot conversion

### DIFF
--- a/cost_gformer/__init__.py
+++ b/cost_gformer/__init__.py
@@ -1,6 +1,7 @@
 """Base package for the CoST-GFormer project."""
 
 from .data import DataModule
+from .gtfs import load_gtfs
 from .graph import ExpandedGraph, DynamicGraphHandler
 from .embedding import Embedding, SpatioTemporalEmbedding
 from .attention import Attention, UnifiedSpatioTemporalAttention
@@ -26,4 +27,5 @@ __all__ = [
     "cross_entropy_loss",
     "CoSTGFormer",
     "Trainer",
+    "load_gtfs",
 ]

--- a/cost_gformer/gtfs.py
+++ b/cost_gformer/gtfs.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+"""Utilities for loading GTFS feeds into :class:`GraphSnapshot` sequences."""
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Iterable, Optional
+import csv
+import io
+import os
+import zipfile
+
+import numpy as np
+from google.transit import gtfs_realtime_pb2
+
+from .data import GraphSnapshot, DynamicGraphDataset
+
+
+# ---------------------------------------------------------------------------
+# Helper parsing utilities
+# ---------------------------------------------------------------------------
+
+def _open_gtfs_file(path: str, name: str):
+    """Return a text file handle for a file within a GTFS feed."""
+    if os.path.isdir(path):
+        return open(os.path.join(path, name), "r", encoding="utf-8")
+    if zipfile.is_zipfile(path):
+        zf = zipfile.ZipFile(path)
+        return io.TextIOWrapper(zf.open(name), encoding="utf-8")
+    raise FileNotFoundError(path)
+
+
+def _parse_time(value: str) -> int:
+    h, m, s = value.split(":")
+    return int(h) * 3600 + int(m) * 60 + int(s)
+
+
+@dataclass
+class Segment:
+    trip_id: str
+    stop_seq: int
+    u: int
+    v: int
+    depart: int
+    arrive: int
+
+
+def parse_gtfs_static(path: str) -> Tuple[Dict[str, int], List[Segment]]:
+    """Parse a minimal subset of a GTFS static feed."""
+
+    with _open_gtfs_file(path, "stops.txt") as f:
+        reader = csv.DictReader(f)
+        stop_map = {row["stop_id"]: idx for idx, row in enumerate(reader)}
+
+    stop_times: Dict[str, List[Tuple[int, str, int, int]]] = {}
+    with _open_gtfs_file(path, "stop_times.txt") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            trip = row["trip_id"]
+            seq = int(row["stop_sequence"])
+            stop_id = row["stop_id"]
+            arr = _parse_time(row["arrival_time"])
+            dep = _parse_time(row["departure_time"])
+            stop_times.setdefault(trip, []).append((seq, stop_id, arr, dep))
+
+    for lst in stop_times.values():
+        lst.sort(key=lambda x: x[0])
+
+    segments: List[Segment] = []
+    for trip_id, lst in stop_times.items():
+        for i in range(len(lst) - 1):
+            seq, sid, _, dep = lst[i]
+            _, sid_next, arr_next, _ = lst[i + 1]
+            u = stop_map[sid]
+            v = stop_map[sid_next]
+            segments.append(Segment(trip_id, seq, u, v, dep, arr_next))
+
+    return stop_map, segments
+
+
+def parse_gtfs_realtime(path: str) -> Dict[Tuple[str, int], int]:
+    """Parse GTFS real-time TripUpdate delays."""
+
+    feed = gtfs_realtime_pb2.FeedMessage()
+    with open(path, "rb") as f:
+        feed.ParseFromString(f.read())
+
+    delays: Dict[Tuple[str, int], int] = {}
+    for ent in feed.entity:
+        if not ent.HasField("trip_update"):
+            continue
+        tu = ent.trip_update
+        trip_id = tu.trip.trip_id
+        for stu in tu.stop_time_update:
+            seq = stu.stop_sequence
+            delay = 0
+            if stu.HasField("departure") and stu.departure.HasField("delay"):
+                delay = stu.departure.delay
+            elif stu.HasField("arrival") and stu.arrival.HasField("delay"):
+                delay = stu.arrival.delay
+            delays[(trip_id, seq)] = delay
+    return delays
+
+
+# ---------------------------------------------------------------------------
+# Main conversion function
+# ---------------------------------------------------------------------------
+
+def build_snapshots(
+    segments: Iterable[Segment],
+    delays: Optional[Dict[Tuple[str, int], int]] = None,
+) -> DynamicGraphDataset:
+    """Convert segments to :class:`DynamicGraphDataset`."""
+
+    delays = delays or {}
+
+    by_time: Dict[int, List[Segment]] = {}
+    for seg in segments:
+        by_time.setdefault(seg.depart, []).append(seg)
+
+    snapshots: List[GraphSnapshot] = []
+    for t in sorted(by_time.keys()):
+        edges: List[Tuple[int, int]] = []
+        static_feat: Dict[Tuple[int, int], np.ndarray] = {}
+        dyn_feat: Dict[Tuple[int, int], np.ndarray] = {}
+        for seg in by_time[t]:
+            e = (seg.u, seg.v)
+            edges.append(e)
+            travel = seg.arrive - seg.depart
+            static_feat[e] = np.array([float(travel)], dtype=np.float32)
+            delay = float(delays.get((seg.trip_id, seg.stop_seq), 0))
+            dyn_feat[e] = np.array([delay], dtype=np.float32)
+        snap = GraphSnapshot(
+            time=t,
+            edges=edges,
+            static_edge_feat=static_feat,
+            dynamic_edge_feat=dyn_feat,
+        )
+        snapshots.append(snap)
+
+    return DynamicGraphDataset(snapshots)
+
+
+def load_gtfs(static_path: str, realtime_path: Optional[str] = None) -> DynamicGraphDataset:
+    """High level loader for GTFS feeds."""
+
+    _, segments = parse_gtfs_static(static_path)
+    delays = parse_gtfs_realtime(realtime_path) if realtime_path else None
+    return build_snapshots(segments, delays)
+
+
+__all__ = [
+    "parse_gtfs_static",
+    "parse_gtfs_realtime",
+    "build_snapshots",
+    "load_gtfs",
+]

--- a/tests/test_gtfs_loader.py
+++ b/tests/test_gtfs_loader.py
@@ -1,0 +1,58 @@
+import csv
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from cost_gformer.gtfs import load_gtfs
+
+from google.transit import gtfs_realtime_pb2
+
+
+def _make_sample_gtfs(root: Path) -> None:
+    (root / "stops.txt").write_text("stop_id,stop_name\nA,Stop A\nB,Stop B\nC,Stop C\n")
+
+    with open(root / "trips.txt", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["route_id", "service_id", "trip_id"])
+        w.writerow(["R1", "S1", "T1"])
+
+    with open(root / "stop_times.txt", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["trip_id", "arrival_time", "departure_time", "stop_id", "stop_sequence"])
+        w.writerow(["T1", "08:00:00", "08:00:00", "A", 1])
+        w.writerow(["T1", "08:10:00", "08:10:00", "B", 2])
+        w.writerow(["T1", "08:20:00", "08:20:00", "C", 3])
+
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    ent = feed.entity.add()
+    ent.id = "1"
+    tu = ent.trip_update
+    tu.trip.trip_id = "T1"
+    stu = tu.stop_time_update.add()
+    stu.stop_sequence = 1
+    stu.departure.delay = 30
+    stu2 = tu.stop_time_update.add()
+    stu2.stop_sequence = 2
+    stu2.departure.delay = 60
+    with open(root / "rt.pb", "wb") as f:
+        f.write(feed.SerializeToString())
+
+
+def test_load_gtfs(tmp_path: Path) -> None:
+    _make_sample_gtfs(tmp_path)
+    dataset = load_gtfs(str(tmp_path), str(tmp_path / "rt.pb"))
+    assert len(dataset) == 2
+
+    snap0 = dataset[0]
+    assert snap0.time == 8 * 3600
+    assert snap0.edges == [(0, 1)]
+    assert float(snap0.static_edge_feat[(0, 1)][0]) == 600.0
+    assert float(snap0.dynamic_edge_feat[(0, 1)][0]) == 30.0
+
+    snap1 = dataset[1]
+    assert snap1.time == 8 * 3600 + 10 * 60
+    assert snap1.edges == [(1, 2)]
+    assert float(snap1.static_edge_feat[(1, 2)][0]) == 600.0
+    assert float(snap1.dynamic_edge_feat[(1, 2)][0]) == 60.0


### PR DESCRIPTION
## Summary
- implement GTFS feed parsing helpers for static and real-time data
- add high-level `load_gtfs` function
- expose loader via package `__init__`
- provide unit test for snapshot generation from sample feed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fddf4bd0c832386adbe246269a86a