### PR TITLE
Implement full CoSTGFormer forward pipeline

### DIFF
--- a/cost_gformer/model.py
+++ b/cost_gformer/model.py
@@ -12,6 +12,7 @@ from .embedding import Embedding
 from .attention import Attention, UnifiedSpatioTemporalAttention
 from .memory import ShortTermMemory, LongTermMemory
 from .heads import TravelTimeHead, CrowdingHead, mse_loss, cross_entropy_loss
+from .data import GraphSnapshot
 
 
 class CoSTGFormer:
@@ -31,22 +32,58 @@ class CoSTGFormer:
         self.travel_head = TravelTimeHead(embed_dim)
         self.crowd_head = CrowdingHead(embed_dim)
 
-    def forward(self, embeddings: "np.ndarray", edges: "np.ndarray"):
-        """Return predictions for the given edges."""
-        self.stm.write(embeddings)
-        self.ltm.write(embeddings)
+    def forward(self, history: "list[GraphSnapshot]"):
+        """Predict travel time and crowding for the next step.
 
-        # Short-term context
-        ctx = self.stm.read_all()
-        emb_with_stm = 0.5 * embeddings + 0.5 * ctx
+        Parameters
+        ----------
+        history:
+            Sequence of :class:`GraphSnapshot` objects forming the input window.
 
+        Returns
+        -------
+        Tuple[np.ndarray, np.ndarray]
+            Travel time and crowding predictions for the edges of the latest
+            snapshot in ``history``.
+        """
+
+        if self.embedding is None:
+            raise ValueError("An Embedding module must be provided")
+
+        # ------------------------------------------------------------------
+        # 1) Compute spatio-temporal node embeddings for the input window
+        # ------------------------------------------------------------------
+        embeds = self.embedding.encode_window(history)
+
+        # Update short and long term memories with each step
+        for step in embeds:
+            self.stm.write(step)
+            self.ltm.write(step)
+
+        # ------------------------------------------------------------------
+        # 2) Apply unified spatio-temporal attention over all embeddings
+        # ------------------------------------------------------------------
+        n_steps, num_nodes, dim = embeds.shape
+        attended = self.usta(embeds.reshape(-1, dim)).reshape(n_steps, num_nodes, dim)
+
+        # 3) Retrieve STM context and fuse with LTM for the latest step
+        latest = attended[-1]
+        stm_ctx = self.stm.read_all()
+        fused = 0.5 * latest + 0.5 * stm_ctx
+        for v in range(num_nodes):
+            fused[v] = self.ltm.fuse(v, fused[v])
+
+        # ------------------------------------------------------------------
+        # 4) Compute multi-task predictions from shared edge representations
+        # ------------------------------------------------------------------
+        edges = history[-1].edges
         preds_tt = []
         preds_cr = []
         for u, v in edges:
-            u_emb = self.ltm.fuse(u, emb_with_stm[u])
-            v_emb = self.ltm.fuse(v, emb_with_stm[v])
-            preds_tt.append(self.travel_head(u_emb, v_emb))
-            preds_cr.append(self.crowd_head(u_emb, v_emb))
+            pair = np.concatenate([fused[u], fused[v]], axis=-1)
+            preds_tt.append(self.travel_head.mlp(pair).squeeze(-1))
+            preds_cr.append(self.crowd_head.mlp(pair))
+
         travel = np.stack(preds_tt)
         crowd = np.stack(preds_cr)
         return travel, crowd
@@ -54,15 +91,14 @@ class CoSTGFormer:
     # --------------------------------------------------------------
     def loss(
         self,
-        embeddings: "np.ndarray",
-        edges: "np.ndarray",
+        history: "list[GraphSnapshot]",
         tt_target: "np.ndarray",
         cr_target: "np.ndarray",
         lambda_tt: float = 1.0,
         lambda_cr: float = 1.0,
         classification: bool = True,
     ) -> float:
-        travel, crowd = self.forward(embeddings, edges)
+        travel, crowd = self.forward(history)
         l_tt = mse_loss(travel, tt_target)
         if classification:
             l_cr = cross_entropy_loss(crowd, cr_target.astype(int))


### PR DESCRIPTION
## Summary
- update CoSTGFormer forward pass to compute spatio-temporal embeddings
- apply unified attention and memory fusion
- compute travel-time and crowding heads from shared representations
- adjust loss method accordingly

## Testing
- `pip install numpy protobuf pytest -q`
- `pip install gtfs-realtime-bindings -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe322fac883239a6711c5bf1fec81