### PR TITLE
Switch to torch computations

### DIFF
--- a/cost_gformer/attention.py
+++ b/cost_gformer/attention.py
@@ -7,7 +7,8 @@ projections and memory-efficient computation.
 """
 
 
-import numpy as np
+import numpy as np  # for type hints
+import torch
 
 
 class Attention:
@@ -33,6 +34,7 @@ class UnifiedSpatioTemporalAttention:
         num_experts: int = 2,
         top_k: int = 5,
         rng: np.random.Generator | None = None,
+        device: str | torch.device = "cpu",
     ) -> None:
         if embed_dim % num_heads != 0:
             raise ValueError("embed_dim must be divisible by num_heads")
@@ -43,52 +45,61 @@ class UnifiedSpatioTemporalAttention:
         self.top_k = top_k
 
         rng = np.random.default_rng() if rng is None else rng
+        self.device = torch.device(device)
 
         head_dim = embed_dim // num_heads
         self.head_dim = head_dim
 
         # Query projection shared across experts
         self.W_q = (
-            rng.standard_normal((embed_dim, num_heads, head_dim), dtype=np.float32)
-            / np.sqrt(embed_dim)
-        )
+            torch.from_numpy(rng.standard_normal((embed_dim, num_heads, head_dim), dtype=np.float32))
+            / torch.sqrt(torch.tensor(embed_dim, dtype=torch.float32))
+        ).to(self.device)
 
         # Expert-specific key/value projections
         self.W_k = (
-            rng.standard_normal(
-                (num_experts, embed_dim, num_heads, head_dim), dtype=np.float32
+            torch.from_numpy(
+                rng.standard_normal(
+                    (num_experts, embed_dim, num_heads, head_dim), dtype=np.float32
+                )
             )
-            / np.sqrt(embed_dim)
-        )
+            / torch.sqrt(torch.tensor(embed_dim, dtype=torch.float32))
+        ).to(self.device)
         self.W_v = (
-            rng.standard_normal(
-                (num_experts, embed_dim, num_heads, head_dim), dtype=np.float32
+            torch.from_numpy(
+                rng.standard_normal(
+                    (num_experts, embed_dim, num_heads, head_dim), dtype=np.float32
+                )
             )
-            / np.sqrt(embed_dim)
-        )
+            / torch.sqrt(torch.tensor(embed_dim, dtype=torch.float32))
+        ).to(self.device)
 
-        self.W_g = rng.standard_normal((embed_dim, num_experts), dtype=np.float32)
+        self.W_g = torch.from_numpy(
+            rng.standard_normal((embed_dim, num_experts), dtype=np.float32)
+        ).to(self.device)
 
         self.W_o = (
-            rng.standard_normal((num_heads * head_dim, embed_dim), dtype=np.float32)
-            / np.sqrt(num_heads * head_dim)
-        )
+            torch.from_numpy(
+                rng.standard_normal((num_heads * head_dim, embed_dim), dtype=np.float32)
+            )
+            / torch.sqrt(torch.tensor(num_heads * head_dim, dtype=torch.float32))
+        ).to(self.device)
 
     # ------------------------------------------------------------------
     @staticmethod
-    def _phi(x: np.ndarray) -> np.ndarray:
+    def _phi(x: torch.Tensor) -> torch.Tensor:
         """Feature map for linear attention."""
-        return np.maximum(0.0, x) + 1e-6
+        return torch.relu(x) + 1e-6
 
     @staticmethod
-    def _softmax(x: np.ndarray) -> np.ndarray:
-        x = x - np.max(x)
-        e = np.exp(x)
-        return e / e.sum(axis=-1, keepdims=True)
+    def _softmax(x: torch.Tensor) -> torch.Tensor:
+        x = x - x.max()
+        e = torch.exp(x)
+        return e / e.sum(dim=-1, keepdim=True)
 
     def _attention_single(
-        self, q: np.ndarray, k: np.ndarray, v: np.ndarray
-    ) -> np.ndarray:
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> torch.Tensor:
         """Compute attention with pruning for one head."""
 
         phi_q = self._phi(q)
@@ -96,12 +107,11 @@ class UnifiedSpatioTemporalAttention:
 
         scores = phi_q @ phi_k.T
 
-        # Prune to top-k neighbors for each query
         n = q.shape[0]
-        out = np.zeros_like(q)
+        out = torch.zeros_like(q)
         for i in range(n):
             s = scores[i]
-            idx = np.argpartition(-s, self.top_k)[: self.top_k]
+            idx = torch.topk(s, self.top_k).indices
             weights = self._softmax(s[idx])
             out[i] = weights @ v[idx]
         return out
@@ -111,29 +121,28 @@ class UnifiedSpatioTemporalAttention:
         """Apply USTA over a set of node-time embeddings."""
 
         n, _ = h.shape
+        h_t = torch.from_numpy(h).to(self.device)
 
-        # Compute queries shared by experts
-        q = np.einsum("nd,dhe->nhe", h, self.W_q)
+        q = torch.einsum("nd,dhe->nhe", h_t, self.W_q)
 
-        # Compute gating weights
-        gate_logits = h @ self.W_g
+        gate_logits = h_t @ self.W_g
         gates = self._softmax(gate_logits)
 
         head_outputs = []
         for head in range(self.num_heads):
             q_h = q[:, head, :]
-            head_out = np.zeros((n, self.head_dim), dtype=np.float32)
+            head_out = torch.zeros((n, self.head_dim), dtype=torch.float32, device=self.device)
             for e in range(self.num_experts):
                 g = gates[:, e, None]
-                k = h @ self.W_k[e, :, head, :]
-                v = h @ self.W_v[e, :, head, :]
+                k = h_t @ self.W_k[e, :, head, :]
+                v = h_t @ self.W_v[e, :, head, :]
                 attn = self._attention_single(q_h, k, v)
                 head_out += g * attn
             head_outputs.append(head_out)
 
-        concat = np.concatenate(head_outputs, axis=-1)
+        concat = torch.cat(head_outputs, dim=-1)
         out = concat @ self.W_o
-        return out
+        return out.cpu().numpy()
 
 
 __all__ = ["Attention", "UnifiedSpatioTemporalAttention"]

--- a/cost_gformer/memory.py
+++ b/cost_gformer/memory.py
@@ -11,7 +11,8 @@ The memory system is separated into three conceptual blocks:
 These classes are placeholders and only document the intended behavior.
 """
 
-import numpy as np
+import numpy as np  # for type hints
+import torch
 
 
 class UltraShortTermAttention:
@@ -27,34 +28,37 @@ class UltraShortTermAttention:
 class ShortTermMemory:
     """Cyclic buffer storing recent node embeddings."""
 
-    def __init__(self, size: int = 128, num_nodes: int | None = None, embed_dim: int | None = None) -> None:
+    def __init__(self, size: int = 128, num_nodes: int | None = None, embed_dim: int | None = None, device: str | torch.device = "cpu") -> None:
         self.size = int(size)
         self.num_nodes = None if num_nodes is None else int(num_nodes)
         self.embed_dim = None if embed_dim is None else int(embed_dim)
+        self.device = torch.device(device)
         self._ptr = 0
         self._filled = 0
-        self.buffer: np.ndarray | None = None
+        self.buffer: torch.Tensor | None = None
 
         if self.num_nodes is not None and self.embed_dim is not None:
             self._init_buffer()
 
     # ------------------------------------------------------------------
     def _init_buffer(self) -> None:
-        self.buffer = np.zeros(
-            (self.size, self.num_nodes, self.embed_dim), dtype=np.float32
+        self.buffer = torch.zeros(
+            (self.size, self.num_nodes, self.embed_dim), dtype=torch.float32, device=self.device
         )
 
     # ------------------------------------------------------------------
-    def write(self, embeddings: "np.ndarray") -> None:
+    def write(self, embeddings: "np.ndarray | torch.Tensor") -> None:
         """Store a new set of node embeddings."""
 
+        if isinstance(embeddings, np.ndarray):
+            embeddings = torch.from_numpy(embeddings)
         if self.buffer is None:
             self.num_nodes, self.embed_dim = embeddings.shape
             self._init_buffer()
         if embeddings.shape != (self.num_nodes, self.embed_dim):
             raise ValueError("embedding shape mismatch")
 
-        self.buffer[self._ptr] = embeddings
+        self.buffer[self._ptr] = embeddings.to(self.device)
         self._ptr = (self._ptr + 1) % self.size
         self._filled = min(self._filled + 1, self.size)
 
@@ -63,19 +67,19 @@ class ShortTermMemory:
         """Return the mean embedding for ``node`` across the buffer."""
 
         if self.buffer is None or self._filled == 0:
-            return np.zeros(self.embed_dim, dtype=np.float32)
+            return torch.zeros(self.embed_dim, dtype=torch.float32).cpu().numpy()
 
         data = self.buffer[: self._filled, node]
-        return data.mean(axis=0)
+        return data.mean(dim=0).cpu().numpy()
 
     def read_all(self) -> "np.ndarray":
         """Return mean embeddings for all nodes."""
 
         if self.buffer is None or self._filled == 0:
-            return np.zeros((self.num_nodes, self.embed_dim), dtype=np.float32)
+            return torch.zeros((self.num_nodes, self.embed_dim), dtype=torch.float32).cpu().numpy()
 
         data = self.buffer[: self._filled]
-        return data.mean(axis=0)
+        return data.mean(dim=0).cpu().numpy()
 
     # ------------------------------------------------------------------
     def __repr__(self) -> str:  # pragma: no cover - simple repr
@@ -92,6 +96,7 @@ class LongTermMemory:
         num_centroids: int = 8,
         buffer_size: int = 1024,
         rng: "np.random.Generator | None" = None,
+        device: str | torch.device = "cpu",
     ) -> None:
 
         self.num_nodes = int(num_nodes)
@@ -101,46 +106,49 @@ class LongTermMemory:
 
         rng = np.random.default_rng() if rng is None else rng
         self.rng = rng
+        self.device = torch.device(device)
 
-        self.buffer = np.zeros(
-            (self.buffer_size, self.num_nodes, self.embed_dim), dtype=np.float32
+        self.buffer = torch.zeros(
+            (self.buffer_size, self.num_nodes, self.embed_dim), dtype=torch.float32, device=self.device
         )
         self._ptr = 0
         self._filled = 0
 
-        self.centroids = np.zeros(
-            (self.num_nodes, self.num_centroids, self.embed_dim), dtype=np.float32
+        self.centroids = torch.zeros(
+            (self.num_nodes, self.num_centroids, self.embed_dim), dtype=torch.float32, device=self.device
         )
         # Gating projection for fuse()
         self.W_g = (
-            rng.standard_normal((2 * self.embed_dim, self.embed_dim), dtype=np.float32)
-            / np.sqrt(2 * self.embed_dim)
-        )
+            torch.from_numpy(rng.standard_normal((2 * self.embed_dim, self.embed_dim), dtype=np.float32))
+            / torch.sqrt(torch.tensor(2 * self.embed_dim, dtype=torch.float32))
+        ).to(self.device)
 
     # ------------------------------------------------------------------
     @staticmethod
-    def _softmax(x: "np.ndarray") -> "np.ndarray":
+    def _softmax(x: torch.Tensor) -> torch.Tensor:
         x = x - x.max()
-        e = np.exp(x)
+        e = torch.exp(x)
         return e / e.sum()
 
     @staticmethod
-    def _sigmoid(x: "np.ndarray") -> "np.ndarray":
-        return 1.0 / (1.0 + np.exp(-x))
+    def _sigmoid(x: torch.Tensor) -> torch.Tensor:
+        return 1.0 / (1.0 + torch.exp(-x))
 
     # ------------------------------------------------------------------
-    def write(self, embeddings: "np.ndarray") -> None:
+    def write(self, embeddings: "np.ndarray | torch.Tensor") -> None:
         """Store new embeddings in the circular buffer."""
 
+        if isinstance(embeddings, np.ndarray):
+            embeddings = torch.from_numpy(embeddings)
         if embeddings.shape != (self.num_nodes, self.embed_dim):
             raise ValueError("embedding shape mismatch")
 
-        self.buffer[self._ptr] = embeddings
+        self.buffer[self._ptr] = embeddings.to(self.device)
         self._ptr = (self._ptr + 1) % self.buffer_size
         self._filled = min(self._filled + 1, self.buffer_size)
 
     # ------------------------------------------------------------------
-    def build(self, embeddings: "np.ndarray | None" = None, iters: int = 10) -> None:
+    def build(self, embeddings: "np.ndarray | torch.Tensor | None" = None, iters: int = 10) -> None:
         """Cluster embeddings to initialise the centroids.
 
         Parameters
@@ -156,6 +164,8 @@ class LongTermMemory:
             if self._filled == 0:
                 return
             embeddings = self.buffer[: self._filled]
+        elif isinstance(embeddings, np.ndarray):
+            embeddings = torch.from_numpy(embeddings)
 
         if embeddings.ndim != 3:
             raise ValueError("embeddings must be (steps, nodes, dim)")
@@ -172,46 +182,55 @@ class LongTermMemory:
 
             # Initialise centroids with random samples
             idx = self.rng.choice(n_samples, self.num_centroids, replace=n_samples < self.num_centroids)
-            centers = X[idx].copy()
+            centers = X[idx].clone()
 
             for _ in range(max(1, iters)):
                 # assign points to nearest centroid
-                dists = ((X[:, None, :] - centers[None, :, :]) ** 2).sum(axis=2)
-                assign = dists.argmin(axis=1)
+                dists = ((X[:, None, :] - centers[None, :, :]) ** 2).sum(dim=2)
+                assign = dists.argmin(dim=1)
                 # update centroids
                 for k in range(self.num_centroids):
                     mask = assign == k
                     if mask.any():
-                        centers[k] = X[mask].mean(axis=0)
+                        centers[k] = X[mask].mean(dim=0)
 
             self.centroids[v] = centers
 
     # ------------------------------------------------------------------
-    def read(self, node: int, embedding: "np.ndarray") -> "np.ndarray":
+    def read(self, node: int, embedding: "np.ndarray | torch.Tensor") -> "np.ndarray":
         """Retrieve context vector for a node embedding."""
 
+        if isinstance(embedding, np.ndarray):
+            embedding = torch.from_numpy(embedding).to(self.device)
         cents = self.centroids[node]
         sims = embedding @ cents.T
         weights = self._softmax(sims)
-        return weights @ cents
+        return (weights @ cents).cpu().numpy()
 
-    def read_all(self, embeddings: "np.ndarray") -> "np.ndarray":
+    def read_all(self, embeddings: "np.ndarray | torch.Tensor") -> "np.ndarray":
         """Retrieve memories for a batch of embeddings."""
 
+        if isinstance(embeddings, np.ndarray):
+            embeddings = torch.from_numpy(embeddings)
         if embeddings.shape != (self.num_nodes, self.embed_dim):
             raise ValueError("embedding shape mismatch")
 
-        out = np.zeros_like(embeddings)
+        out = torch.zeros_like(embeddings)
         for v in range(self.num_nodes):
-            out[v] = self.read(v, embeddings[v])
-        return out
+            out[v] = torch.from_numpy(self.read(v, embeddings[v]))
+        return out.cpu().numpy()
 
-    def fuse(self, node: int, embedding: "np.ndarray") -> "np.ndarray":
+    def fuse(self, node: int, embedding: "np.ndarray | torch.Tensor") -> "np.ndarray":
         """Fuse current embedding with retrieved memory."""
 
-        mem = self.read(node, embedding)
-        gate = self._sigmoid(np.concatenate([embedding, mem]) @ self.W_g)
-        return gate * embedding + (1.0 - gate) * mem
+        if isinstance(embedding, np.ndarray):
+            embedding_t = torch.from_numpy(embedding).to(self.device)
+        else:
+            embedding_t = embedding.to(self.device)
+        mem = torch.from_numpy(self.read(node, embedding_t)).to(self.device)
+        gate = self._sigmoid(torch.cat([embedding_t, mem]) @ self.W_g)
+        fused = gate * embedding_t + (1.0 - gate) * mem
+        return fused.cpu().numpy()
 
     # ------------------------------------------------------------------
     def __repr__(self) -> str:  # pragma: no cover - simple repr

--- a/cost_gformer/train_gtfs.py
+++ b/cost_gformer/train_gtfs.py
@@ -23,6 +23,12 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--epochs", type=int, default=5, help="Training epochs")
     p.add_argument("--lr", type=float, default=0.01, help="Learning rate")
     p.add_argument(
+        "--device",
+        choices=["cpu", "cuda"],
+        default="cpu",
+        help="Computation device",
+    )
+    p.add_argument(
         "--regression",
         action="store_true",
         help="Use regression for crowd level instead of classification",
@@ -45,6 +51,7 @@ def main() -> None:
         lr=args.lr,
         epochs=args.epochs,
         classification=not args.regression,
+        device=args.device,
     )
     trainer.fit()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 protobuf
 gtfs-realtime-bindings
 pytest
+torch


### PR DESCRIPTION
## Summary
- use torch tensors in embedding, attention, memory and trainer
- allow choosing CPU or GPU via Trainer and CLI
- add torch to dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_684fe8e2d4348323a9782794dcabe942