### PR TITLE
Fix attention initialization and detach arrays

### DIFF
--- a/cost_gformer/attention.py
+++ b/cost_gformer/attention.py
@@ -101,7 +101,7 @@ class Attention:
 
         concat = out.reshape(out.shape[0], -1)
         result = concat @ self.W_o
-        return result.cpu().numpy()
+        return result.detach().cpu().numpy()
 
 class UnifiedSpatioTemporalAttention:
     """USTA with learnable projections and gated mixture-of-experts."""
@@ -188,7 +188,8 @@ class UnifiedSpatioTemporalAttention:
         out = torch.zeros_like(q)
         for i in range(n):
             s = scores[i]
-            idx = torch.topk(s, self.top_k).indices
+            k = min(self.top_k, s.shape[0])
+            idx = torch.topk(s, k).indices
             weights = self._softmax(s[idx])
             out[i] = weights @ v[idx]
         return out
@@ -219,7 +220,7 @@ class UnifiedSpatioTemporalAttention:
 
         concat = torch.cat(head_outputs, dim=-1)
         out = concat @ self.W_o
-        return out.cpu().numpy()
+        return out.detach().cpu().numpy()
 
 
 __all__ = ["Attention", "UnifiedSpatioTemporalAttention"]

--- a/cost_gformer/heads.py
+++ b/cost_gformer/heads.py
@@ -27,7 +27,7 @@ class MLP:
             x_t = torch.from_numpy(x).to(self.w1.device)
             hidden = torch.relu(x_t @ self.w1 + self.b1)
             out = hidden @ self.w2 + self.b2
-            return out.cpu().numpy()
+            return out.detach().cpu().numpy()
         hidden = torch.relu(x @ self.w1 + self.b1)
         return hidden @ self.w2 + self.b2
 


### PR DESCRIPTION
## Summary
- fix Attention creation in `CoSTGFormer`
- lazily allocate long term memory using dataset node count
- detach tensors before converting to numpy
- handle small neighbor sets in UnifiedSpatioTemporalAttention
- update MLP to detach outputs

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=$(pwd) pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685017f4a614832387a9ec0e5c000245