### PR TITLE
Add user-friendly training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ dataset using the script in `cost_gformer/train_gtfs.py`:
 python -m cost_gformer.train_gtfs PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED]
 ```
 
+Convenience wrapper scripts are available so you don't have to type the
+full Python command each time.  On Linux or macOS run
+
+```bash
+./train_gtfs.sh PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [options]
+```
+
+On Windows use
+
+```
+train_gtfs.bat PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [options]
+```
+
 Key command line options include:
 
 - `--history` / `--horizon` – size of the input and forecast windows.

--- a/train_gtfs.bat
+++ b/train_gtfs.bat
@@ -1,0 +1,9 @@
+@echo off
+REM Wrapper script for running CoST-GFormer training on a GTFS dataset.
+REM Usage: train_gtfs.bat STATIC_FEED [REALTIME_FEED] [options]
+
+SET PYTHON=python
+where python3 >nul 2>&1
+IF %ERRORLEVEL%==0 SET PYTHON=python3
+
+%PYTHON% -m cost_gformer.train_gtfs %*

--- a/train_gtfs.sh
+++ b/train_gtfs.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+# Wrapper script for running CoST-GFormer training on a GTFS dataset.
+# Usage: ./train_gtfs.sh STATIC_FEED [REALTIME_FEED] [options]
+# All arguments are passed directly to the Python entry point.
+
+# Detect a Python interpreter
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+    PYTHON=python
+else
+    echo "Error: Python is not installed." >&2
+    exit 1
+fi
+
+exec "$PYTHON" -m cost_gformer.train_gtfs "$@"


### PR DESCRIPTION
## Summary
- add cross-platform `train_gtfs.sh` helper script
- add Windows `train_gtfs.bat` helper script
- document usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68504d6699a8832383743000b0320613