### PR TITLE
Enable sparse eigen decomposition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ protobuf==6.31.1
 gtfs-realtime-bindings==1.0.0
 pytest==8.3.5
 torch==2.7.1
+scipy==1.15.3

--- a/requirements_freeze.txt
+++ b/requirements_freeze.txt
@@ -40,6 +40,7 @@ pydantic==1.10.15
 pyright==1.1.401
 pytest==8.3.5
 ruff==0.11.10
+scipy==1.15.3
 sniffio==1.3.1
 starlette==0.27.0
 sympy==1.14.0

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -1,6 +1,10 @@
 import numpy as np
 import pytest
 import torch
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from cost_gformer.attention import Attention, UnifiedSpatioTemporalAttention
 from cost_gformer.memory import ShortTermMemory, LongTermMemory

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,21 @@
+import numpy as np
+import torch
+
+from cost_gformer.embedding import SpatioTemporalEmbedding
+from cost_gformer.data import generate_synthetic_dataset
+
+
+def test_sparse_embedding():
+    dataset = generate_synthetic_dataset(num_nodes=6, num_snapshots=1, seed=0)
+    edges = dataset[0].edges
+    dyn_dim = len(next(iter(dataset[0].dynamic_edge_feat.values())))
+    stm = SpatioTemporalEmbedding(
+        num_nodes=6,
+        static_edges=edges,
+        dynamic_dim=dyn_dim,
+        use_sparse=True,
+    )
+    emb = stm.encode_snapshot(dataset[0])
+    assert emb.shape == (6, stm.mlp.b2.numel())
+    assert stm.spectral.dtype == torch.float32
+    assert emb.dtype == np.float32


### PR DESCRIPTION
## Summary
- add `scipy` as a dependency
- allow `SpatioTemporalEmbedding` to use sparse eigendecomposition via scipy
- support fallback dense path for small graphs or when disabled
- ensure tests can import the package
- add unit test for sparse embedding path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506029972083238c91078cd4433c99