### PR TITLE
Improve LongTermMemory vectorization

### DIFF
--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -30,3 +30,14 @@ def test_ltm_build_and_retrieve():
     assert read.shape == (dim,)
     fused = ltm.fuse(0, history[-1, 0])
     assert fused.shape == (dim,)
+
+
+def test_ltm_build_with_external_embeddings():
+    num_nodes = 2
+    dim = 3
+    rng = np.random.default_rng(1)
+    history = rng.standard_normal((4, num_nodes, dim), dtype=np.float32)
+    ltm = LongTermMemory(num_nodes=num_nodes, embed_dim=dim, num_centroids=3)
+    ltm.build(history, iters=2)
+    out = ltm.read_all(history[-1])
+    assert out.shape == (num_nodes, dim)


### PR DESCRIPTION
## Summary
- vectorize centroid updates in `LongTermMemory.build`
- add regression test for building from external embeddings

## Testing
- `pytest tests/test_memory.py::test_ltm_build_and_retrieve -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*
- `pytest tests/test_memory.py::test_ltm_build_with_external_embeddings -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68513552d644832380f42b0eda241dcb