### PR TITLE
Vectorize USTA attention

### DIFF
--- a/cost_gformer/attention.py
+++ b/cost_gformer/attention.py
@@ -184,14 +184,13 @@ class UnifiedSpatioTemporalAttention:
 
         scores = phi_q @ phi_k.T
 
-        n = q.shape[0]
-        out = torch.zeros_like(q)
-        for i in range(n):
-            s = scores[i]
-            k = min(self.top_k, s.shape[0])
-            idx = torch.topk(s, k).indices
-            weights = self._softmax(s[idx])
-            out[i] = weights @ v[idx]
+        top_k = min(self.top_k, scores.shape[1])
+
+        values, indices = torch.topk(scores, top_k, dim=1)
+        weights = self._softmax(values)
+
+        selected_v = v[indices]
+        out = torch.einsum("nk,nkh->nh", weights, selected_v)
         return out
 
     # ------------------------------------------------------------------

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -10,6 +10,22 @@ from cost_gformer.attention import Attention, UnifiedSpatioTemporalAttention
 from cost_gformer.memory import ShortTermMemory, LongTermMemory
 
 
+def _attention_single_reference(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, top_k: int) -> torch.Tensor:
+    phi_q = torch.relu(q) + 1e-6
+    phi_k = torch.relu(k) + 1e-6
+    scores = phi_q @ phi_k.T
+
+    n = q.shape[0]
+    out = torch.zeros_like(q)
+    for i in range(n):
+        s = scores[i]
+        k_val = min(top_k, s.shape[0])
+        idx = torch.topk(s, k_val).indices
+        weights = torch.softmax(s[idx], dim=-1)
+        out[i] = weights @ v[idx]
+    return out
+
+
 def _run_attention(device: str) -> None:
     rng = np.random.default_rng(0)
     x = rng.standard_normal((3, 8), dtype=np.float32)
@@ -41,6 +57,40 @@ def _run_usta(device: str) -> None:
     assert isinstance(out, np.ndarray)
 
 
+def _run_usta_equivalence(device: str) -> None:
+    rng = np.random.default_rng(2)
+    n = 4
+    dim = 10
+    h = rng.standard_normal((n, dim), dtype=np.float32)
+    usta = UnifiedSpatioTemporalAttention(
+        embed_dim=dim, num_heads=2, num_experts=2, top_k=3, device=device
+    )
+
+    out = usta(h)
+
+    h_t = torch.from_numpy(h).to(device)
+    q = torch.einsum("nd,dhe->nhe", h_t, usta.W_q)
+    gate_logits = torch.einsum("nd,dhe->nhe", h_t, usta.W_g)
+    gates = torch.softmax(gate_logits, dim=-1)
+
+    head_outputs = []
+    for head in range(usta.num_heads):
+        q_h = q[:, head, :]
+        head_out = torch.zeros((n, usta.head_dim), dtype=torch.float32, device=device)
+        for e in range(usta.num_experts):
+            g = gates[:, head, e, None]
+            k = h_t @ usta.W_k[e, :, head, :]
+            v = h_t @ usta.W_v[e, :, head, :]
+            attn = _attention_single_reference(q_h, k, v, usta.top_k)
+            head_out += g * attn
+        head_outputs.append(head_out)
+    concat = torch.cat(head_outputs, dim=-1)
+    manual_out = concat @ usta.W_o
+    manual_out = manual_out.detach().cpu().numpy()
+
+    np.testing.assert_allclose(out, manual_out, rtol=1e-5, atol=1e-6)
+
+
 def test_attention_cpu():
     _run_attention("cpu")
 
@@ -54,6 +104,15 @@ def test_usta_cpu():
     _run_usta("cpu")
 
 
+def test_usta_equivalence_cpu():
+    _run_usta_equivalence("cpu")
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda not available")
 def test_usta_cuda():
     _run_usta("cuda")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda not available")
+def test_usta_equivalence_cuda():
+    _run_usta_equivalence("cuda")


### PR DESCRIPTION
## Summary
- vectorize `_attention_single` by performing topk for all rows at once
- gather `v` vectors in batch and compute softmax in bulk
- add regression tests comparing vectorized attention to reference implementation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68513721d43c832384c58d3a72dc6062