### PR TITLE
Compute loss per sample

### DIFF
--- a/cost_gformer/trainer.py
+++ b/cost_gformer/trainer.py
@@ -203,11 +203,10 @@ class Trainer:
             cr_acc += acc * edges.shape[0]
             n_samples += edges.shape[0]
 
-        horizon = len(future)
         if n_samples == 0:
             return torch.tensor(0.0), 0.0, 0.0, 0.0, 0
 
-        loss = total_loss / horizon
+        loss = total_loss / n_samples
         return loss, mae_tt / n_samples, rmse_tt / n_samples, cr_acc / n_samples, n_samples
 
     # --------------------------------------------------------------


### PR DESCRIPTION
## Summary
- compute training loss per sample instead of per horizon in `_forward_multi`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68515cee90d083239729b888f3542cad