### PR TITLE
Fix batch loss scaling in trainer

### DIFF
--- a/cost_gformer/trainer.py
+++ b/cost_gformer/trainer.py
@@ -233,7 +233,7 @@ class Trainer:
                 tt_rmse += rmse * n
                 cr_acc += acc * n
             if batch_samples > 0:
-                batch_loss.backward()
+                (batch_loss / batch_samples).backward()
                 self.optimizer.step()
         if self.scheduler is not None:
             self.scheduler.step()


### PR DESCRIPTION
## Summary
- scale the accumulated batch loss by the number of samples before backpropagation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68515e3507708323acef9c33a1f2c2c2