### PR TITLE
Enforce occupancy availability for crowding training

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ dataset using the script in `cost_gformer/train_gtfs.py`:
 python -m cost_gformer.train_gtfs PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [PATH_TO_VEHICLE_FEED]
 ```
 
+Crowding prediction requires that edge occupancy values are available. These
+can be obtained from vehicle position feeds or supplied through a custom data
+loader.
+
 Convenience wrapper scripts are available so you don't have to type the
 full Python command each time.  On Linux or macOS run
 

--- a/cost_gformer/trainer.py
+++ b/cost_gformer/trainer.py
@@ -53,7 +53,11 @@ def _prepare_targets(
             raise ValueError("dynamic edge feature must contain at least one value")
         tt_vals.append(float(feat[0]))
 
-        crowd_val = float(feat[1]) if len(feat) > 1 else 0.0
+        if len(feat) < 2:
+            raise ValueError(
+                "crowding prediction enabled but dynamic edge feature lacks occupancy"
+            )
+        crowd_val = float(feat[1])
         if classification:
             label = int(crowd_val * num_classes)
             if label >= num_classes:

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -5,7 +5,9 @@ from cost_gformer.trainer import Trainer
 
 
 def test_trainer_basic():
-    dataset = generate_synthetic_dataset(num_nodes=3, num_snapshots=7, seed=0)
+    dataset = generate_synthetic_dataset(
+        num_nodes=3, num_snapshots=7, dynamic_dim=2, seed=0
+    )
     data = DataModule(dataset, history=2, horizon=1)
     model = CoSTGFormer()
     w_before = model.travel_head.mlp.w1.clone()
@@ -15,7 +17,9 @@ def test_trainer_basic():
 
 
 def test_trainer_multistep():
-    dataset = generate_synthetic_dataset(num_nodes=3, num_snapshots=8, seed=1)
+    dataset = generate_synthetic_dataset(
+        num_nodes=3, num_snapshots=8, dynamic_dim=2, seed=1
+    )
     data = DataModule(dataset, history=2, horizon=2)
     model = CoSTGFormer()
     trainer = Trainer(model=model, data=data, epochs=1, batch_size=1)


### PR DESCRIPTION
## Summary
- require occupancy data when preparing crowding targets
- clarify GTFS training docs about needed occupancy info
- adjust trainer tests to use synthetic dataset with two dynamic features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685177978e348323995603aae49c64c8