### PR TITLE
Support vehicle occupancy in GTFS loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ You can train the model on a GTFS (General Transit Feed Specification)
 dataset using the script in `cost_gformer/train_gtfs.py`:
 
 ```bash
-python -m cost_gformer.train_gtfs PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED]
+python -m cost_gformer.train_gtfs PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [PATH_TO_VEHICLE_FEED]
 ```
 
 Convenience wrapper scripts are available so you don't have to type the
 full Python command each time.  On Linux or macOS run
 
 ```bash
-./train_gtfs.sh PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [options]
+./train_gtfs.sh PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [PATH_TO_VEHICLE_FEED] [options]
 ```
 
 On Windows use
 
 ```
-train_gtfs.bat PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [options]
+train_gtfs.bat PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [PATH_TO_VEHICLE_FEED] [options]
 ```
 
 Key command line options include:

--- a/cost_gformer/train_gtfs.py
+++ b/cost_gformer/train_gtfs.py
@@ -24,6 +24,11 @@ def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Train CoST-GFormer on GTFS data")
     p.add_argument("static", help="Path to GTFS static feed")
     p.add_argument("realtime", nargs="?", help="Optional path to GTFS realtime feed")
+    p.add_argument(
+        "vehicle",
+        nargs="?",
+        help="Optional path to GTFS vehicle positions feed",
+    )
     p.add_argument("--history", type=int, default=3, help="Number of history steps")
     p.add_argument("--horizon", type=int, default=1, help="Forecast horizon")
     p.add_argument("--epochs", type=int, default=5, help="Training epochs")
@@ -75,7 +80,7 @@ def main() -> None:
             level=logging.INFO,
             format="%(asctime)s - %(levelname)s - %(message)s",
         )
-    dataset = load_gtfs(args.static, args.realtime)
+    dataset = load_gtfs(args.static, args.realtime, args.vehicle)
     data = DataModule(dataset, history=args.history, horizon=args.horizon)
     model = CoSTGFormer(device=args.device)
     schedule = None

--- a/train_gtfs.bat
+++ b/train_gtfs.bat
@@ -1,6 +1,6 @@
 @echo off
 REM Wrapper script for running CoST-GFormer training on a GTFS dataset.
-REM Usage: train_gtfs.bat STATIC_FEED [REALTIME_FEED] [options]
+REM Usage: train_gtfs.bat STATIC_FEED [REALTIME_FEED] [VEHICLE_FEED] [options]
 
 SET PYTHON=python
 where python3 >nul 2>&1

--- a/train_gtfs.sh
+++ b/train_gtfs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 # Wrapper script for running CoST-GFormer training on a GTFS dataset.
-# Usage: ./train_gtfs.sh STATIC_FEED [REALTIME_FEED] [options]
+# Usage: ./train_gtfs.sh STATIC_FEED [REALTIME_FEED] [VEHICLE_FEED] [options]
 # All arguments are passed directly to the Python entry point.
 
 # Detect a Python interpreter


### PR DESCRIPTION
## Summary
- parse vehicle position feeds for occupancy values
- include vehicle occupancies when building graph snapshots
- allow `load_gtfs` to accept an optional vehicle positions file
- extend CLI wrapper scripts and argument parser
- document new CLI argument and test occupancy features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517294f6648323a99c673e63a0493d