### PR TITLE
Normalize GTFS occupancy percentages

### DIFF
--- a/cost_gformer/gtfs.py
+++ b/cost_gformer/gtfs.py
@@ -126,7 +126,7 @@ def parse_vehicle_positions(path: str) -> Dict[Tuple[str, int], float]:
             continue
 
         if vp.HasField("occupancy_percentage"):
-            value = float(vp.occupancy_percentage)
+            value = float(vp.occupancy_percentage) / 100.0
         elif vp.HasField("occupancy_status"):
             value = float(int(vp.occupancy_status))
         else:


### PR DESCRIPTION
## Summary
- normalize occupancy percentages in `parse_vehicle_positions`
- load `load_gtfs` module in tests without importing heavy dependencies
- verify occupancies are stored as values between 0 and 1

## Testing
- `pytest tests/test_gtfs_loader.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851802508a48323be83835f29072e44