### PR TITLE
Fix time encoding to accept seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ dataset using the script in `cost_gformer/train_gtfs.py`:
 python -m cost_gformer.train_gtfs PATH_TO_STATIC_FEED [PATH_TO_REALTIME_FEED] [PATH_TO_VEHICLE_FEED]
 ```
 
+Snapshot times throughout the library are expressed in seconds past midnight.
+For example `08:00` would be represented as `8 * 3600`.
+
 Crowding prediction requires that edge occupancy values are available. These
 can be obtained from vehicle position feeds or supplied through a custom data
 loader.

--- a/cost_gformer/embedding.py
+++ b/cost_gformer/embedding.py
@@ -116,8 +116,8 @@ class SpatioTemporalEmbedding:
     # ------------------------------------------------------------------
     @staticmethod
     def _time_encoding(t: int) -> torch.Tensor:
-        hour = torch.tensor(float(t % 24))
-        day = torch.tensor(float(t % 7))
+        hour = torch.tensor(float((t // 3600) % 24))
+        day = torch.tensor(float((t // 86400) % 7))
         enc = torch.stack(
             [
                 torch.sin(2 * torch.pi * hour / 24),

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -83,3 +83,18 @@ def test_dynamic_aggregation_consistency():
     ref /= count[:, None]
 
     assert np.allclose(agg.numpy(), ref)
+
+
+def test_time_encoding_seconds():
+    enc = SpatioTemporalEmbedding._time_encoding(8 * 3600)
+    hour = torch.tensor(8.0)
+    day = torch.tensor(0.0)
+    expected = torch.stack(
+        [
+            torch.sin(2 * torch.pi * hour / 24),
+            torch.cos(2 * torch.pi * hour / 24),
+            torch.sin(2 * torch.pi * day / 7),
+            torch.cos(2 * torch.pi * day / 7),
+        ]
+    ).to(torch.float32)
+    assert torch.allclose(enc, expected)


### PR DESCRIPTION
## Summary
- make `_time_encoding` work with snapshot time expressed in seconds
- document that times are given in seconds
- test the second-based time encoding

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851945a53608323bfa4c7f98d6d2a3f