### PR TITLE
Implement early stopping and seed flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ Key command line options include:
 - `--lr` – learning rate for the SGD trainer.
 - `--device` – choose `cpu` or `cuda`.
 - `--regression` – use regression instead of classification for crowd level.
+- `--patience` – stop training if validation loss doesn't improve for N epochs.
+- `--seed` – random seed for reproducible initialisation.
+
+Use the seed option to reproduce experiments across runs as it affects weight
+initialisation and dataset shuffling.
 
 The spatio-temporal embedding module also exposes a `use_sparse` flag. When
 enabled (the default) and the graph is large, spectral coordinates are computed

--- a/cost_gformer/embedding.py
+++ b/cost_gformer/embedding.py
@@ -50,11 +50,13 @@ class SpatioTemporalEmbedding:
         hidden_dim: int = 64,
         device: str | torch.device = "cpu",
         use_sparse: bool = True,
+        seed: int = 0,
     ) -> None:
         self.num_nodes = num_nodes
         self.dynamic_dim = dynamic_dim
         self.device = torch.device(device)
         self.use_sparse = use_sparse
+        self.seed = seed
 
         if self.use_sparse and num_nodes > spectral_dim + 1:
             import scipy.sparse as sp
@@ -104,7 +106,8 @@ class SpatioTemporalEmbedding:
         spectral_dim = sdim
 
         in_dim = spectral_dim + 4 + dynamic_dim
-        g = torch.Generator().manual_seed(0)
+        g = torch.Generator().manual_seed(self.seed)
+        torch.manual_seed(self.seed)
         w1 = torch.randn((in_dim, hidden_dim), generator=g, dtype=torch.float32) / torch.sqrt(torch.tensor(in_dim, dtype=torch.float32))
         b1 = torch.zeros(hidden_dim, dtype=torch.float32)
         w2 = torch.randn((hidden_dim, embed_dim), generator=g, dtype=torch.float32) / torch.sqrt(torch.tensor(hidden_dim, dtype=torch.float32))

--- a/cost_gformer/gtfs.py
+++ b/cost_gformer/gtfs.py
@@ -151,6 +151,16 @@ def build_snapshots(
     delays = delays or {}
     occupancies = occupancies or {}
 
+    if occupancies:
+        unique_occ = {float(v) for v in occupancies.values()}
+        if len(unique_occ) <= 1:
+            import logging
+
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "All occupancy values are identical; crowding accuracy will remain 1.0"
+            )
+
     by_time: Dict[int, List[Segment]] = {}
     for seg in segments:
         by_time.setdefault(seg.depart, []).append(seg)

--- a/cost_gformer/train_gtfs.py
+++ b/cost_gformer/train_gtfs.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import argparse
 
 import logging
+import numpy as np
+import torch
 
 from cost_gformer.gtfs import load_gtfs
 from cost_gformer.data import DataModule
@@ -34,6 +36,8 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--epochs", type=int, default=5, help="Training epochs")
     p.add_argument("--lr", type=float, default=0.01, help="Learning rate")
     p.add_argument("--batch-size", type=int, default=1, help="Batch size")
+    p.add_argument("--patience", type=int, default=0, help="Early stopping patience")
+    p.add_argument("--seed", type=int, default=0, help="Random seed")
     p.add_argument(
         "--lr-step-size",
         type=int,
@@ -80,6 +84,8 @@ def main() -> None:
             level=logging.INFO,
             format="%(asctime)s - %(levelname)s - %(message)s",
         )
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
     dataset = load_gtfs(args.static, args.realtime, args.vehicle)
     data = DataModule(dataset, history=args.history, horizon=args.horizon)
     model = CoSTGFormer(device=args.device)
@@ -95,6 +101,8 @@ def main() -> None:
         classification=not args.regression,
         lr_schedule=schedule,
         device=args.device,
+        patience=args.patience,
+        seed=args.seed,
     )
     trainer.fit()
 


### PR DESCRIPTION
## Summary
- add `--patience` and `--seed` flags to `train_gtfs.py`
- support reproducible initialization in `SpatioTemporalEmbedding`
- honour the seed inside `Trainer` and use early stopping
- warn if GTFS occupancy labels are constant
- document the new options

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c856094c8323a301ae0e96b5335c